### PR TITLE
Make booking page visible to all staff

### DIFF
--- a/salon_flask/routes/main.py
+++ b/salon_flask/routes/main.py
@@ -684,8 +684,8 @@ def pos_bookings():
     GET: عرض قائمة الحجوزات ونماذج الإدخال.
     POST: تسجيل حجز جديد.
     """
-    # السماح فقط لمنفذ المبيعات أو المدير
-    if session.get('role') not in ['accountant', 'admin']:
+    # السماح لمنفذ المبيعات، المدير، والموظفين بالوصول للعرض
+    if session.get('role') not in ['accountant', 'admin', 'staff']:
         return "Access Denied", 403
 
     # جلب جميع الموظفين والخدمات والعملاء والحجوزات
@@ -695,6 +695,9 @@ def pos_bookings():
     bookings = Booking.query.order_by(Booking.date.desc(), Booking.time.desc()).all()
 
     if request.method == 'POST':
+        # تقييد إنشاء الحجوزات على المحاسب أو المدير فقط
+        if session.get('role') not in ['accountant', 'admin']:
+            return "Access Denied", 403
         # جمع بيانات الحجز من الفورم
         customer_name = request.form.get('customer_name')
         customer_phone = request.form.get('customer_phone')

--- a/salon_flask/templates/pos_bookings.html
+++ b/salon_flask/templates/pos_bookings.html
@@ -14,7 +14,8 @@
 
 <main class="p-6">
 
-  <!-- زر إضافة حجز -->
+  <!-- زر إضافة حجز: يظهر فقط للمحاسب والمدير -->
+  {% if session.get('role') in ['accountant', 'admin'] %}
   <div class="mb-4 text-right">
     <button 
       class="bg-pink-400 text-white py-2 px-4 rounded-lg hover:bg-pink-500 transition"
@@ -22,6 +23,7 @@
       إضافة حجز جديد
     </button>
   </div>
+  {% endif %}
 
   <!-- جدول الحجوزات -->
   <div class="overflow-x-auto bg-white rounded-lg shadow p-4">


### PR DESCRIPTION
Allow staff to view the bookings page while restricting booking creation and the 'Add Booking' button to accountants and admins.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ffc82f8-de32-4407-b949-e99fcb1af08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ffc82f8-de32-4407-b949-e99fcb1af08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

