### PR TITLE
Fix employee not found on login

### DIFF
--- a/salon_flask/routes/main.py
+++ b/salon_flask/routes/main.py
@@ -637,12 +637,8 @@ def employee_bookings():
         return "Access Denied", 403
 
     # جلب الموظف الحالي
-    employee = (
-        db.session.query(Employee)
-        .join(User, Employee.user_id == User.id)
-        .filter(User.username == session.get('username'))
-        .first()
-    )
+    current_user_id = session.get('user_id')
+    employee = Employee.query.filter_by(user_id=current_user_id).first()
     if not employee:
         return "Employee not found", 404
 
@@ -658,12 +654,8 @@ def employee_inventory():
     if session.get('role') != 'staff':
         return "Access Denied", 403
 
-    employee = (
-        db.session.query(Employee)
-        .join(User, Employee.user_id == User.id)
-        .filter(User.username == session.get('username'))
-        .first()
-    )
+    current_user_id = session.get('user_id')
+    employee = Employee.query.filter_by(user_id=current_user_id).first()
     if not employee:
         return "Employee not found", 404
 
@@ -684,12 +676,8 @@ def employee_consume_inventory():
     if session.get('role') != 'staff':
         return "Access Denied", 403
 
-    employee = (
-        db.session.query(Employee)
-        .join(User, Employee.user_id == User.id)
-        .filter(User.username == session.get('username'))
-        .first()
-    )
+    current_user_id = session.get('user_id')
+    employee = Employee.query.filter_by(user_id=current_user_id).first()
     if not employee:
         return "Employee not found", 404
 


### PR DESCRIPTION
Store `user_id` in session and create `Employee` records for staff on first login, then fetch employee data using `user_id` to resolve "Employee not found" errors.

The "Employee not found" error occurred because staff users might not have had an associated `Employee` record, or the existing lookup relied on joining `User` and `Employee` tables via `username` which was less direct. This change ensures an `Employee` record is created if missing for staff and simplifies employee data retrieval by using the `user_id` directly from the session.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c53067a-b1e2-4ec4-ae10-77a17ba1957f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c53067a-b1e2-4ec4-ae10-77a17ba1957f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

