### PR TITLE
Style navbar buttons light green black text

### DIFF
--- a/salon_flask/templates/layout.html
+++ b/salon_flask/templates/layout.html
@@ -10,14 +10,14 @@
   <style>
     .topnav-btn {
       background-color: #90EE90;
-      color: #0f5132;
+      color: #000000;
       border-radius: .5rem;
       padding: .25rem .75rem;
       margin: 0 .25rem;
     }
     .topnav-btn:hover, .topnav-btn:focus {
       background-color: #7fdc7f;
-      color: #0f5132;
+      color: #000000;
     }
     /* Light green buttons with black text for Bootstrap success buttons */
     .btn-success {


### PR DESCRIPTION
Update navbar button text color to black to match the user's request for light green buttons with black text.

---
<a href="https://cursor.com/background-agent?bcId=bc-161c1053-173c-4129-a159-5928d61baef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-161c1053-173c-4129-a159-5928d61baef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

