### PR TITLE
Fix staff display for accounting roles

### DIFF
--- a/salon_flask/routes/main.py
+++ b/salon_flask/routes/main.py
@@ -126,7 +126,7 @@ def add_employee():
     db.session.add(user)
 
     # إضافة الموظف
-    employee = Employee(name=name, specialty=request.form.get('specialty'), user=user)
+    employee = Employee(name=name, specialty=request.form.get('specialty'), role=role, user=user)
     db.session.add(employee)
 
     db.session.commit()


### PR DESCRIPTION
Fix: Ensure the selected employee role is correctly saved, preventing it from defaulting to 'staff'.

---
<a href="https://cursor.com/background-agent?bcId=bc-283f9bf5-5243-44eb-95b6-6829ba4a9cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-283f9bf5-5243-44eb-95b6-6829ba4a9cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

