### PR TITLE
Add service option to gallery upload

### DIFF
--- a/salon_flask/templates/admin_gallery.html
+++ b/salon_flask/templates/admin_gallery.html
@@ -3,7 +3,10 @@
 <div class="py-2">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h2 class="m-0">رفع صور للمعرض</h2>
-    <a class="btn btn-outline-secondary" href="{{ url_for('main.gallery') }}">عرض المعرض</a>
+    <div class="d-flex gap-2">
+      <a class="btn btn-outline-secondary" href="{{ url_for('main.gallery') }}">عرض المعرض</a>
+      <a class="btn btn-primary" href="{{ url_for('main.admin_services') }}">إضافة الخدمات</a>
+    </div>
   </div>
 
   <form action="{{ url_for('main.admin_gallery') }}" method="post" enctype="multipart/form-data" class="card p-3 shadow-sm">


### PR DESCRIPTION
Add "إضافة الخدمات" button to the gallery upload page to provide a direct link to the services administration page.

---
<a href="https://cursor.com/background-agent?bcId=bc-d54c8770-65a3-48c6-b947-722d0fbe3337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d54c8770-65a3-48c6-b947-722d0fbe3337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

