### PR TITLE
Configure accountant sales point view

### DIFF
--- a/salon_flask/templates/products.html
+++ b/salon_flask/templates/products.html
@@ -18,6 +18,7 @@
 </header>
 
 <main class="p-6">
+  {% if session.get('role') == 'admin' %}
   <h2 class="text-2xl font-semibold text-pink-600 mb-4">قسم الاستهلاك الداخلي</h2>
 
   {% if consumption_items %}
@@ -35,19 +36,18 @@
       {% if item.quantity <= item.reorder_level %}
       <div class="mt-2 text-xs text-red-600">تنبيه: المخزون منخفض</div>
       {% endif %}
-      {% if session.get('role') == 'admin' %}
       <form action="{{ url_for('main.update_product_item') }}" method="post" class="mt-3 flex items-center gap-2">
         <input type="hidden" name="item_id" value="{{ item.id }}">
         <input type="hidden" name="for_sale" value="1">
         <input type="number" step="0.01" min="0" name="sale_price" placeholder="سعر البيع" class="border rounded px-2 py-1 w-32">
         <button class="bg-green-500 text-white px-3 py-1 rounded">تحويل للبيع</button>
       </form>
-      {% endif %}
     </div>
     {% endfor %}
   </div>
   {% else %}
   <div class="bg-white p-6 rounded-lg shadow text-center text-gray-600 mb-8">لا توجد منتجات للاستهلاك الداخلي.</div>
+  {% endif %}
   {% endif %}
 
   <h2 class="text-2xl font-semibold text-pink-600 mb-4">قسم البيع</h2>


### PR DESCRIPTION
Hide the internal consumption section on the products page for non-admin users to display only saleable products in POS.

---
<a href="https://cursor.com/background-agent?bcId=bc-758c8350-7725-4675-b100-27628f3ff9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-758c8350-7725-4675-b100-27628f3ff9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

