### PR TITLE
Link homepage gallery to admin images and categories

### DIFF
--- a/salon_flask/routes/main.py
+++ b/salon_flask/routes/main.py
@@ -31,7 +31,8 @@ def home():
     # واجهة العملاء هي الصفحة الرئيسية
     services = Service.query.all()
     employees = Employee.query.all()
-    return render_template('customer_home.html', services=services, employees=employees)
+    categories = _load_gallery_categories()
+    return render_template('customer_home.html', services=services, employees=employees, categories=categories)
 
 
 

--- a/salon_flask/templates/customer_home.html
+++ b/salon_flask/templates/customer_home.html
@@ -69,11 +69,25 @@
 
 <!-- 🔹 معرض -->
 <section id="gallery" class="py-16 bg-pink-50">
-  <h2 class="text-3xl font-bold text-center text-pink-600 mb-12" data-aos="fade-up">معرضنا</h2>
+  <h2 class="text-3xl font-bold text-center text-pink-600 mb-6" data-aos="fade-up">معرضنا</h2>
   <div class="grid gap-6 px-6 max-w-6xl mx-auto md:grid-cols-3" data-aos="zoom-in">
-    <img src="https://images.unsplash.com/photo-1582095133179-298b5a9c5ac1" class="rounded-xl shadow-lg hover:scale-105 transition" alt="">
-    <img src="https://images.unsplash.com/photo-1599382109329-ecb9a3bbf4f6" class="rounded-xl shadow-lg hover:scale-105 transition" alt="">
-    <img src="https://images.unsplash.com/photo-1621609767370-b0c2f9c4d1f6" class="rounded-xl shadow-lg hover:scale-105 transition" alt="">
+    {% if categories %}
+      {% for cat in categories[:6] %}
+      <a href="{{ url_for('main.gallery_category', category_key=cat.key) }}" class="block rounded-xl shadow-lg overflow-hidden hover:scale-105 transition bg-white">
+        {% if cat.cover_url %}
+        <img src="{{ cat.cover_url }}" class="w-full h-48 object-cover" alt="{{ cat.title }}">
+        {% else %}
+        <div class="w-full h-48 bg-pink-100 flex items-center justify-center text-pink-600">لا صورة</div>
+        {% endif %}
+        <div class="px-3 py-2 text-center text-pink-700 font-semibold">{{ cat.title }}</div>
+      </a>
+      {% endfor %}
+    {% else %}
+      <div class="col-span-full text-center text-gray-500">لا توجد فئات للعرض حالياً</div>
+    {% endif %}
+  </div>
+  <div class="text-center mt-6">
+    <a href="{{ url_for('main.gallery') }}" class="inline-block bg-white text-pink-600 hover:bg-pink-100 transition rounded-lg px-4 py-2">عرض كل المعرض</a>
   </div>
 </section>
 


### PR DESCRIPTION
Display admin-defined gallery categories dynamically on the homepage.

---
<a href="https://cursor.com/background-agent?bcId=bc-30ca90fb-9ea4-44f6-83c4-6a8e12da6d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30ca90fb-9ea4-44f6-83c4-6a8e12da6d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

