### PR TITLE
Fix account manager dashboard url routing

### DIFF
--- a/salon_flask/routes/auth.py
+++ b/salon_flask/routes/auth.py
@@ -24,7 +24,7 @@ def login():
             if role == 'admin':
                 return redirect(url_for('main.admin_dashboard'))
             elif role == 'account_manager':
-                return redirect(url_for('main.account_manager_dashboard'))
+                return redirect(url_for('main.accounting_dashboard'))
             elif role == 'accountant':
                 # فقط الوصول لمنفذ البيع
                 return redirect(url_for('main.pos_dashboard'))


### PR DESCRIPTION
Fix `BuildError` by correcting the endpoint name from `main.account_manager_dashboard` to `main.accounting_dashboard` in the `auth` blueprint.

---
<a href="https://cursor.com/background-agent?bcId=bc-1255b766-319c-4bdc-8139-0638b3a11231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1255b766-319c-4bdc-8139-0638b3a11231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

