### PR TITLE
Add loyalty card button to sales port

### DIFF
--- a/salon_flask/templates/pos_dashboard.html
+++ b/salon_flask/templates/pos_dashboard.html
@@ -14,6 +14,9 @@
         <nav class="flex items-center gap-2">
             <a href="{{ url_for('main.pos_bookings') }}" class="bg-green-400 text-white py-2 px-4 rounded-lg shadow hover:bg-green-500 transition">الحجوزات</a>
             <a href="{{ url_for('main.products_page') }}" class="bg-green-400 text-white py-2 px-4 rounded-lg shadow hover:bg-green-500 transition">المنتجات</a>
+            {% if session.get('role') == 'admin' %}
+            <a href="{{ url_for('loyalty.loyalty_dashboard') }}" class="bg-green-400 text-white py-2 px-4 rounded-lg shadow hover:bg-green-500 transition">كروت الولاء</a>
+            {% endif %}
         </nav>
     </div>
 </header>


### PR DESCRIPTION
Add a 'Loyalty Cards' button to the POS dashboard header, visible only to admins, to navigate to the loyalty dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7683331-c393-4ae6-8349-33e2f2056c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7683331-c393-4ae6-8349-33e2f2056c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

