### PR TITLE
Add barcode generation button to loyalty page

### DIFF
--- a/salon_flask/requirements.txt
+++ b/salon_flask/requirements.txt
@@ -5,3 +5,4 @@ Flask-JWT-Extended
 Werkzeug
 qrcode
 Pillow
+python-barcode

--- a/salon_flask/routes/loyalty.py
+++ b/salon_flask/routes/loyalty.py
@@ -57,6 +57,26 @@ def qr_png(customer_id: int):
     return send_file(buf, mimetype='image/png', download_name=f"loyalty_{customer.id}.png")
 
 
+@loyalty_bp.route('/loyalty/barcode/<int:customer_id>.png')
+def barcode_png(customer_id: int):
+    customer = Customer.query.get_or_404(customer_id)
+    code_data = build_membership_code(customer)
+    try:
+        import barcode as _barcode
+        from barcode.writer import ImageWriter
+    except Exception:
+        abort(500, description='إنشاء الباركود غير متاح حالياً. الرجاء تثبيت python-barcode.')
+    code128 = _barcode.get('code128', code_data, writer=ImageWriter())
+    buf = BytesIO()
+    code128.write(buf, options={
+        'write_text': False,
+        'module_height': 18.0,
+        'module_width': 0.4,
+        'quiet_zone': 2.0
+    })
+    buf.seek(0)
+    return send_file(buf, mimetype='image/png', download_name=f"loyalty_barcode_{customer.id}.png")
+
 @loyalty_bp.route('/loyalty/scan')
 def scan():
     cid = request.args.get('cid', type=int)

--- a/salon_flask/templates/loyalty_dashboard.html
+++ b/salon_flask/templates/loyalty_dashboard.html
@@ -39,6 +39,9 @@
           <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('loyalty.qr_png', customer_id=c.id) }}" target="_blank">
             <i class="bi bi-qr-code"></i> QR
           </a>
+          <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('loyalty.barcode_png', customer_id=c.id) }}" target="_blank">
+            <i class="bi bi-upc"></i> باركود
+          </a>
           <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('loyalty.scan', cid=c.id) }}" target="_blank">
             <i class="bi bi-upc-scan"></i> افتح في POS
           </a>


### PR DESCRIPTION
Add a button to the loyalty dashboard to generate a Code128 barcode for each customer's loyalty card.

This allows users to easily generate and view/download barcodes for customer loyalty cards directly from the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c83b6ca-6c5f-4a45-a8c0-c82418f663bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c83b6ca-6c5f-4a45-a8c0-c82418f663bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

